### PR TITLE
feat: automatically process citations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .env
 content
+docs
+litdb.bib

--- a/fmt-citations.sh
+++ b/fmt-citations.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+cp -r notebooks/ docs/
+cd notebooks/
+
+for i in **/*.mdx; do
+    [ -f "$i" ] || break
+    echo "$i"
+    OUTPUT_PATH="../docs/${i}"
+    pandoc \
+        -f markdown \
+        -t gfm+smart+hard_line_breaks \
+        --citeproc \
+        --csl ../vendor/vancouver-brackets.csl \
+        --bibliography=../litdb.bib \
+        -o "$OUTPUT_PATH" \
+        <<< cat "$i"
+    CITATIONS_START_AT=$(sed -n '/<div id="refs" class="references csl-bib-body">/=' "$OUTPUT_PATH")
+    if [ -n "$CITATIONS_START_AT" ]; then
+        sed \
+            -i '' -e "${CITATIONS_START_AT},\$s/<http/http/g" \
+            -i '' -e "${CITATIONS_START_AT},\$s/><\/span>$/<\/span>/g" \
+            "${OUTPUT_PATH}"
+    fi
+done
+

--- a/fmt-citations.sh
+++ b/fmt-citations.sh
@@ -11,8 +11,8 @@
 #
 # sed: macOS 15.5
 
-cp -r notebooks/ docs/
-cd notebooks/
+cp -r content/ docs/
+cd content/
 
 for i in **/*.mdx; do
     [ -f "$i" ] || break

--- a/fmt-citations.sh
+++ b/fmt-citations.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# DEPENDENCIES: pandoc, sed (macOS/BSD version)
+#
+# version info provided below just in case:
+#
+# pandoc --version:
+# 3.7.0.2
+# Features: +server +lua
+# Scripting engine: Lua 5.4
+#
+# sed: macOS 15.5
+
 cp -r notebooks/ docs/
 cd notebooks/
 

--- a/fmt-citations.sh
+++ b/fmt-citations.sh
@@ -7,6 +7,8 @@ for i in **/*.mdx; do
     [ -f "$i" ] || break
     echo "$i"
     OUTPUT_PATH="../docs/${i}"
+
+    # the actual magic
     pandoc \
         -f markdown \
         -t gfm+smart+hard_line_breaks \
@@ -15,11 +17,28 @@ for i in **/*.mdx; do
         --bibliography=../litdb.bib \
         -o "$OUTPUT_PATH" \
         <<< cat "$i"
+
+    # find the line where citation info starts, to prevent false hits
     CITATIONS_START_AT=$(sed -n '/<div id="refs" class="references csl-bib-body">/=' "$OUTPUT_PATH")
+
     if [ -n "$CITATIONS_START_AT" ]; then
+        # remove html comments around custom blocks (scans above citation info
+        # to prevent false hits)
+        sed \
+            -i '' -e "1,${CITATIONS_START_AT}s/<!--//g" \
+            -i '' -e "1,${CITATIONS_START_AT}s/-->//g" \
+            "${OUTPUT_PATH}"
+        # remove angle brackets around links in citation info, which break MDX
+        # (scans below citation info start to prevent false hits)
         sed \
             -i '' -e "${CITATIONS_START_AT},\$s/<http/http/g" \
             -i '' -e "${CITATIONS_START_AT},\$s/><\/span>$/<\/span>/g" \
+            "${OUTPUT_PATH}"
+    else
+        # remove html comments around custom blocks
+        sed \
+            -i '' -e "s/<!--//g" \
+            -i '' -e "s/-->//g" \
             "${OUTPUT_PATH}"
     fi
 done

--- a/src/component.ts
+++ b/src/component.ts
@@ -51,5 +51,5 @@ function ihp_block(content: string[]): string {
     return ''
   }
 
-  return `<IhpContact\n\tname={"${content[0]}"}\n\theadshotImgPath={"${content[1]}"}\n\tdescription={"${content[2]}"}\n\tblockContent={"${content[3]}"}\n/>`
+  return `<IhpContact\n\tname={"${content[0]}"}\n\theadshotImgPath={"/${content[1]}"}\n\tdescription={"${content[2]}"}\n\tblockContent={"${content[3]}"}\n/>`
 }

--- a/src/component.ts
+++ b/src/component.ts
@@ -40,7 +40,7 @@ export function type(block: BlockObjectResponse): string {
 
 export function ingest(type: string, content: string[]): string {
   if (componentMap[type]) {
-    return componentMap[type](content)
+    return '<!--\n' + componentMap[type](content) + '\n-->'
   }
 
   return ''

--- a/src/component.ts
+++ b/src/component.ts
@@ -8,6 +8,7 @@ const componentMap: Record<string, (content: string[]) => string> = {
 
 export function delimiterState(block: BlockObjectResponse): boolean | null {
   if (block.type === 'paragraph') {
+    if (block.paragraph.rich_text.length == 0) return null
     const text = block.paragraph.rich_text[0].plain_text.trim().toLowerCase()
 
     if (text.startsWith('%%') && text.endsWith('%%') && text.includes('::')){

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -249,7 +249,7 @@ async function formatContent(contentBlocks: RichTextItemResponse[]): Promise<str
     if (contentBlock.type === 'mention' && contentBlock.mention.type == 'page') {
       const mentionedPageId = contentBlock.mention.page.id
       const possibleCiteKey = await citeKeyFromPageIfPresent(mentionedPageId)
-      if (possibleCiteKey) content = `[@${possibleCiteKey}]`
+      if (possibleCiteKey) content = `[[@${possibleCiteKey}]](#ref-${possibleCiteKey})`
     }
 
     response = response.concat(content)

--- a/vendor/vancouver-brackets.csl
+++ b/vendor/vancouver-brackets.csl
@@ -1,0 +1,351 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" initialize-with-hyphen="false" page-range-format="minimal">
+  <info>
+    <title>Vancouver (brackets)</title>
+    <id>http://www.zotero.org/styles/vancouver-brackets</id>
+    <link href="http://www.zotero.org/styles/vancouver-brackets" rel="self"/>
+    <link href="http://www.nlm.nih.gov/bsd/uniform_requirements.html" rel="documentation"/>
+    <author>
+      <name>Michael Berkowitz</name>
+      <email>mberkowi@gmu.edu</email>
+    </author>
+    <contributor>
+      <name>Sean Takats</name>
+      <email>stakats@gmu.edu</email>
+    </contributor>
+    <contributor>
+      <name>Sebastian Karcher</name>
+    </contributor>
+    <category citation-format="numeric"/>
+    <category field="medicine"/>
+    <summary>Vancouver style as outlined by International Committee of Medical Journal Editors Uniform Requirements for Manuscripts Submitted to Biomedical Journals: Sample References</summary>
+    <updated>2022-04-14T13:48:43+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <date form="text" delimiter=" ">
+      <date-part name="year"/>
+      <date-part name="month" form="short" strip-periods="true"/>
+      <date-part name="day"/>
+    </date>
+    <terms>
+      <term name="collection-editor" form="long">
+        <single>editor</single>
+        <multiple>editors</multiple>
+      </term>
+      <term name="presented at">presented at</term>
+      <term name="available at">available from</term>
+      <term name="section" form="short">sect.</term>
+    </terms>
+  </locale>
+  <locale xml:lang="fr">
+    <date form="text" delimiter=" ">
+      <date-part name="day"/>
+      <date-part name="month" form="short" strip-periods="true"/>
+      <date-part name="year"/>
+    </date>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+      <label form="long" prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor" suffix=".">
+      <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+      <label form="long" prefix=", "/>
+    </names>
+  </macro>
+  <macro name="chapter-marker">
+    <choose>
+      <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
+        <text term="in" text-case="capitalize-first"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <!--discard publisher info for articles-->
+      <if type="article-journal article-magazine article-newspaper" match="none">
+        <group delimiter=": " suffix=";">
+          <choose>
+            <if type="thesis">
+              <text variable="publisher-place" prefix="[" suffix="]"/>
+            </if>
+            <else-if type="speech"/>
+            <else>
+              <text variable="publisher-place"/>
+            </else>
+          </choose>
+          <text variable="publisher"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="URL">
+        <group delimiter=": ">
+          <text term="available at" text-case="capitalize-first"/>
+          <text variable="URL"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="accessed-date">
+    <choose>
+      <if variable="URL">
+        <group prefix="[" suffix="]" delimiter=" ">
+          <text term="cited" text-case="lowercase"/>
+          <date variable="accessed" form="text"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article-journal article-magazine chapter paper-conference article-newspaper review review-book entry-dictionary entry-encyclopedia" match="any">
+        <group suffix="." delimiter=" ">
+          <choose>
+            <if type="article-journal review review-book" match="any">
+              <text variable="container-title" form="short" strip-periods="true"/>
+            </if>
+            <else>
+              <text variable="container-title" strip-periods="true"/>
+            </else>
+          </choose>
+          <choose>
+            <if variable="URL">
+              <text term="internet" prefix="[" suffix="]" text-case="capitalize-first"/>
+            </if>
+          </choose>
+        </group>
+        <text macro="edition" prefix=" "/>
+      </if>
+      <!--add event-name and event-place once they become available-->
+      <else-if type="bill legislation" match="any">
+        <group delimiter=", ">
+          <group delimiter=". ">
+            <text variable="container-title"/>
+            <group delimiter=" ">
+              <text term="section" form="short" text-case="capitalize-first"/>
+              <text variable="section"/>
+            </group>
+          </group>
+          <text variable="number"/>
+        </group>
+      </else-if>
+      <else-if type="speech">
+        <group delimiter=": " suffix=";">
+          <group delimiter=" ">
+            <text variable="genre" text-case="capitalize-first"/>
+            <text term="presented at"/>
+          </group>
+          <text variable="event"/>
+        </group>
+      </else-if>
+      <else>
+        <group delimiter=", " suffix=".">
+          <choose>
+            <if variable="collection-title" match="none">
+              <group delimiter=" ">
+                <label variable="volume" form="short" text-case="capitalize-first"/>
+                <text variable="volume"/>
+              </group>
+            </if>
+          </choose>
+          <text variable="container-title"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <text variable="title"/>
+    <choose>
+      <if type="article-journal article-magazine chapter paper-conference article-newspaper review review-book entry-dictionary entry-encyclopedia" match="none">
+        <choose>
+          <if variable="URL">
+            <text term="internet" prefix=" [" suffix="]" text-case="capitalize-first"/>
+          </if>
+        </choose>
+        <text macro="edition" prefix=". "/>
+      </if>
+    </choose>
+    <choose>
+      <if type="thesis">
+        <text variable="genre" prefix=" [" suffix="]"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper review review-book" match="any">
+        <group suffix=";" delimiter=" ">
+          <date variable="issued" form="text"/>
+          <text macro="accessed-date"/>
+        </group>
+      </if>
+      <else-if type="bill legislation" match="any">
+        <group delimiter=", ">
+          <date variable="issued" delimiter=" ">
+            <date-part name="month" form="short" strip-periods="true"/>
+            <date-part name="day"/>
+          </date>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if type="report">
+        <date variable="issued" delimiter=" ">
+          <date-part name="year"/>
+          <date-part name="month" form="short" strip-periods="true"/>
+        </date>
+        <text macro="accessed-date" prefix=" "/>
+      </else-if>
+      <else-if type="patent">
+        <group suffix=".">
+          <group delimiter=", ">
+            <text variable="number"/>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </group>
+          <text macro="accessed-date" prefix=" "/>
+        </group>
+      </else-if>
+      <else-if type="speech">
+        <group delimiter="; ">
+          <group delimiter=" ">
+            <date variable="issued" delimiter=" ">
+              <date-part name="year"/>
+              <date-part name="month" form="short" strip-periods="true"/>
+              <date-part name="day"/>
+            </date>
+            <text macro="accessed-date"/>
+          </group>
+          <text variable="event-place"/>
+        </group>
+      </else-if>
+      <else>
+        <group suffix=".">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+          <text macro="accessed-date" prefix=" "/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper review review-book" match="any">
+        <text variable="page" prefix=":"/>
+      </if>
+      <else-if type="book" match="any">
+        <text variable="number-of-pages" prefix=" "/>
+        <choose>
+          <if is-numeric="number-of-pages">
+            <label variable="number-of-pages" form="short" prefix=" " plural="never"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <group prefix=" " delimiter=" ">
+          <label variable="page" form="short" plural="never"/>
+          <text variable="page"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="journal-location">
+    <choose>
+      <if type="article-journal article-magazine review review-book" match="any">
+        <text variable="volume"/>
+        <text variable="issue" prefix="(" suffix=")"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="collection-details">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper review review-book" match="none">
+        <choose>
+          <if variable="collection-title">
+            <group delimiter=" " prefix="(" suffix=")">
+              <names variable="collection-editor" suffix=".">
+                <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=", "/>
+              </names>
+              <group delimiter="; ">
+                <text variable="collection-title"/>
+                <group delimiter=" ">
+                  <label variable="volume" form="short"/>
+                  <text variable="volume"/>
+                </group>
+              </group>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="report-details">
+    <choose>
+      <if type="report">
+        <text variable="number" prefix="Report No.: "/>
+      </if>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="[" suffix="]" delimiter=",">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="7" et-al-use-first="6" second-field-align="flush">
+    <layout>
+      <text variable="citation-number" suffix=". "/>
+      <group delimiter=". " suffix=". ">
+        <text macro="author"/>
+        <text macro="title"/>
+      </group>
+      <group delimiter=" " suffix=". ">
+        <group delimiter=": ">
+          <text macro="chapter-marker"/>
+          <group delimiter=" ">
+            <text macro="editor"/>
+            <text macro="container-title"/>
+          </group>
+        </group>
+        <text macro="publisher"/>
+        <group>
+          <text macro="date"/>
+          <text macro="journal-location"/>
+          <text macro="pages"/>
+        </group>
+      </group>
+      <text macro="collection-details" suffix=". "/>
+      <text macro="report-details" suffix=". "/>
+      <text macro="access"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Takes at-mentions of pages in the master lit db, and transforms them into proper Vancouver-format citations.

**new additions**:

- a `citeKeyFromPageIfPresent` function to retrieve the citekey property from a page if it's in the master lit db, and some code in `formatContent` to call this func when page-mentions are detected + reformat the citekey into the required format
- a shell script `fmt-citations.sh` that:
    - leverages [pandoc](https://pandoc.org/) + [CSL files](https://www.zotero.org/styles) to detect the citekeys and reformat them into numbered vancouver citations
    - uses `sed` to clean up the converted files from pandoc for website use

**changes required**:
- we're now wrapping all custom blocks in html comments (`<!--`/`-->`) to prevent pandoc from `\`-escaping our components, as pandoc can't recognise them as html (since they're nonstandard components)
- since i retrieve page info in `citeKeyFromPageIfPresent`, i ended up having to make several layers of functions `async`... sorry about that.

**bonus bugfixes**:
- added a guard in `delimiterState` for empty paragraph blocks to avoid crashing the exporter
- changed the `ihp_block` handler to provide an absolute img path to the component

**notes:**
- `vendor/vancouver-brackets.csl` is just the copied-in CSL file - no need to read it all